### PR TITLE
Moved search pane to unhide google maps controls

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -34,7 +34,7 @@ ul {
 
 #map-canvas {
   position: absolute;
-  top: 0;
+  top: 128px;
   left: 0;
   right: 0;
   bottom: 0;
@@ -126,12 +126,13 @@ main {
   #map-canvas {
     height: 100%;
     width: 70%;
+    top: 0;
     right: 30%;
   }
 
   .search-pane {
     top: 10px;
-    left: 10px;
+    left: 88px;
     width: 30%;
 
   }


### PR DESCRIPTION
On mobile moved map-canvas below header to reveal google maps
controls.
On desktop moved search-pane to the right to reveal google maps
controls. Positioned map-canvas to top to compensate for mobile position
tweak.
