### PR TITLE
Added proper meta tags to render mobile correctly

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,9 @@
 !!! html
-%html
+%html{:lang => 'en'}
   %head
+    %meta{:charset =>'utf-8'}
+    %meta{:'http-equiv' =>'X-UA-Compatible', :content =>'IE=edge'}
+    %meta{:name => 'viewport', :content => 'width=device-width, initial-scale=1'}
     %title Foodfinder
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true


### PR DESCRIPTION
Added the meta tag used in bootstrap to head so that mobile displays
correctly. Additionally, added language to HTML and other default meta
tags as seen in bootstrap.
