### PR TITLE
add postmark to foodfinder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem "geocoder"
 gem 'devise'
+gem 'postmark-rails'
 
 gem 'newrelic_rpm'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,12 @@ GEM
     orm_adapter (0.5.0)
     pg (0.17.1)
     polyglot (0.3.5)
+    postmark (1.3.1)
+      json
+      rake
+    postmark-rails (0.8.0)
+      actionmailer (>= 3.0.0)
+      postmark (~> 1.3.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -181,6 +187,7 @@ DEPENDENCIES
   jquery-rails
   newrelic_rpm
   pg
+  postmark-rails
   pry-debugger
   rails (= 4.1.1)
   rails_12factor

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,9 @@ module Foodfinder
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+   
+    # Postmark config for SMTP
+    config.action_mailer.delivery_method   = :postmark
+    config.action_mailer.postmark_settings = { :api_key => ENV['POSTMARK_API_KEY'] }
   end
 end


### PR DESCRIPTION
untested but needs to be on heroku to test. followed these docs: https://devcenter.heroku.com/articles/postmark#sending-emails-in-ruby-on-rails-3-x

Env variables on prod already set.
